### PR TITLE
fix: large messages get cut

### DIFF
--- a/project/monitor/web/app/dashboard/chat/components/tokenselector.tsx
+++ b/project/monitor/web/app/dashboard/chat/components/tokenselector.tsx
@@ -527,7 +527,7 @@ export function TokenSelector({
                 ? 'bg-[#dae4fbff]'
                 : 'bg-gray-200';
           const bubbleClassName = cn(
-            'max-w-[80%] p-2 rounded-lg shadow-sm transition-colors duration-150',
+            'max-w-[80%] p-2 rounded-lg shadow-sm transition-colors duration-150 inline-flex flex-wrap',
             bubbleColorClass
           );
           return (


### PR DESCRIPTION
When using the chat UI, if you write a large message, it gets cut:
![Screenshot 2024-11-30 at 5 41 54 PM](https://github.com/user-attachments/assets/995f5885-0446-451f-b5a7-153ffdfb6762)

This PR fixes it:
![Screenshot 2024-11-30 at 5 41 35 PM](https://github.com/user-attachments/assets/700428f2-74ac-443f-9f27-610ed75a08e0)
